### PR TITLE
Cleaning up class construction and remove uneeded pagefoldProps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^12.0.0",
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",
+        "clsx": "^1.1.1",
         "eslint-plugin-reload": "^0.3.0",
         "react": "^17.0.2",
         "react-docgen-typescript": "^2.1.0",
@@ -9485,7 +9486,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
       "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -37393,8 +37393,7 @@
     "clsx": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
-      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
-      "dev": true
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
     "co": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "clsx": "^1.1.1",
     "eslint-plugin-reload": "^0.3.0",
     "react": "^17.0.2",
     "react-docgen-typescript": "^2.1.0",

--- a/src/stories/availability-label/AvailabilityLabel.stories.tsx
+++ b/src/stories/availability-label/AvailabilityLabel.stories.tsx
@@ -19,13 +19,6 @@ Available.args = {
   manifestation: "bog",
   availability: "Hjemme",
   status: "available",
-  pagefoldProps: {
-    inherit: false,
-    container: false,
-    size: "xsmall",
-    classes: "availability-label availability-label--unselected text-label",
-    colorClass: "success",
-  },
 };
 
 export const Selected = Template.bind({});
@@ -33,12 +26,6 @@ Selected.args = {
   manifestation: "ebog",
   availability: "Online",
   status: "selected",
-  pagefoldProps: {
-    inherit: false,
-    container: false,
-    size: "none",
-    classes: "availability-label availability-label--selected text-label",
-  },
 };
 
 export const Unavailable = Template.bind({});
@@ -46,11 +33,4 @@ Unavailable.args = {
   manifestation: "lydbog (cd-mp3)",
   availability: "Udlånt",
   status: "unavailable",
-  pagefoldProps: {
-    inherit: false,
-    container: false,
-    size: "xsmall",
-    classes: "availability-label availability-label--unselected text-label",
-    colorClass: "alert",
-  },
 };

--- a/src/stories/availability-label/AvailabilityLabel.tsx
+++ b/src/stories/availability-label/AvailabilityLabel.tsx
@@ -1,42 +1,18 @@
-import { Pagefold, PagefoldProps } from "../pagefold/Pagefold";
+import { Pagefold } from "../pagefold/Pagefold";
+import { withAvailabilityProps } from "./abilityLabel.hoc";
 
 export type AvailabilityLabelPropsType = {
   manifestation: "bog" | "ebog" | "lydbog (net)" | "lydbog (cd-mp3)";
   availability: "Hjemme" | "Online" | "Udlånt";
   status: "available" | "unavailable" | "selected";
-  pagefoldProps: PagefoldProps;
 };
 
 export const AvailabilityLabel = (props: AvailabilityLabelPropsType) => {
   const { manifestation, availability, status } = props;
-
-  const pagefoldProps = { ...props.pagefoldProps };
-
-  function getPageFoldProps(
-    currentStatus: AvailabilityLabelPropsType["status"]
-  ) {
-    if (currentStatus === "selected") {
-      pagefoldProps.size = "none";
-      pagefoldProps.classes =
-        "availability-label availability-label--selected text-label";
-    }
-    if (currentStatus === "available") {
-      pagefoldProps.size = "xsmall";
-      pagefoldProps.classes =
-        "availability-label availability-label--unselected text-label";
-      pagefoldProps.colorClass = "success";
-    }
-    if (currentStatus === "unavailable") {
-      pagefoldProps.size = "xsmall";
-      pagefoldProps.classes =
-        "availability-label availability-label--unselected text-label";
-      pagefoldProps.colorClass = "alert";
-    }
-    return pagefoldProps;
-  }
+  const AvailabilityPagefold = withAvailabilityProps(Pagefold);
 
   return (
-    <Pagefold {...getPageFoldProps(status)}>
+    <AvailabilityPagefold status={status}>
       <img
         className={`availability-label--check ${status}`}
         src="icons/collection/Check.svg"
@@ -45,6 +21,7 @@ export const AvailabilityLabel = (props: AvailabilityLabelPropsType) => {
       <p className="text-label-semibold ml-24">{manifestation.toUpperCase()}</p>
       <div className="availability-label--divider ml-4" />
       <p className="text-label-normal ml-4 mr-8">{availability}</p>
-    </Pagefold>
+    </AvailabilityPagefold>
   );
 };
+

--- a/src/stories/availability-label/abilityLabel.hoc.tsx
+++ b/src/stories/availability-label/abilityLabel.hoc.tsx
@@ -1,0 +1,59 @@
+import clsx from "clsx";
+import { PagefoldProps } from "../pagefold/Pagefold";
+import { AvailabilityLabelPropsType } from "./AvailabilityLabel";
+
+type PropMapItem = Omit<PagefoldProps, "isInheriting" | "isAContainer"> & {
+  classes: string[],
+};
+
+export const withAvailabilityProps =
+<T extends PagefoldProps>
+(Component: React.ComponentType<T>) => {
+
+  const defaultClasses = [
+    "availability-label",
+    "text-label"
+  ];
+
+  return (props: Omit<T, "isInheriting" | "isAContainer" | "size"> & {
+    status: AvailabilityLabelPropsType["status"];
+  }) => {
+    const {status} = props;
+
+    const propMap: {
+      selected: PropMapItem;
+      available: PropMapItem;
+      unavailable: PropMapItem;
+    } = {
+      selected: {
+        size: "none",
+        classes: ["availability-label--selected"],
+      },
+      available: {
+        size: "xsmall",
+        classes: ["availability-label--unselected"],
+        type: "success",
+      },
+      unavailable: {
+        size: "xsmall",
+        classes: ["availability-label--unselected"],
+        type: "alert",
+      },
+    };
+
+    const {classes, ...pageFoldProps} = propMap[status];
+
+    const updatedProps: PagefoldProps = {
+      className: clsx(
+        defaultClasses,
+        classes
+      ),
+      ...pageFoldProps,
+      isInheriting: false,
+      isAContainer: false,
+      ...props,
+    };
+
+    return (<Component {...updatedProps as T} />);
+  };
+};

--- a/src/stories/footer/Footer.tsx
+++ b/src/stories/footer/Footer.tsx
@@ -12,7 +12,7 @@ export const Footer = () => {
       <h2 className="hide-visually">Globale links</h2>
       {/* Footer mobile */}
       <div className="footer__mobile">
-        <Pagefold inherit={true} container={true} size="small">
+        <Pagefold isInheriting={true} isAContainer={true} size="small">
           <div>
             <h3 className="text-header-h4 mb-16">Åbningstider</h3>
             <p className="text-body-medium-regular mb-24">
@@ -87,7 +87,7 @@ export const Footer = () => {
 
       {/* Footer tablet/desktop */}
       <div className="footer__desktop">
-        <Pagefold inherit={true} container={true} size="medium">
+        <Pagefold isInheriting={true} isAContainer={true} size="medium">
           <div className="footer__column-wrapper">
             <div className="footer__column">
               <h3 className="text-header-h4 mb-16">Åbningstider</h3>

--- a/src/stories/header/Header.tsx
+++ b/src/stories/header/Header.tsx
@@ -33,10 +33,10 @@ export const Header = (props: HeaderProps) => {
             <div>
               <div className="header__menu-navigation-mobile">
                 <Pagefold
-                  inherit={false}
-                  container={false}
+                  isInheriting={false}
+                  isAContainer={false}
                   size="small"
-                  classes="header__menu-navigation-button header__button"
+                  className="header__menu-navigation-button header__button"
                   compProps={{
                     id: "header__menu--open",
                     onClick: () => window.eventHeader(),
@@ -105,7 +105,7 @@ export const Header = (props: HeaderProps) => {
         </div>
 
         <div className="header__clock">
-          <Pagefold inherit={false} container={false} size="medium" />
+          <Pagefold isInheriting={false} isAContainer={false} size="medium" />
           <div className="header__clock-items">
             <img
               src={`icons/basic/icon-watch-static.svg`}

--- a/src/stories/pagefold/Pagefold.stories.tsx
+++ b/src/stories/pagefold/Pagefold.stories.tsx
@@ -13,13 +13,13 @@ export default {
     isInheriting: {
       defaultValue: false,
     },
-    container: {
+    isAContainer: {
       defaultValue: true,
     },
     size: {
       defaultValue: "medium",
     },
-    classes: {
+    className: {
       // Only used internally
       control: {
         disable: true,
@@ -31,7 +31,7 @@ export default {
         disable: true,
       },
     },
-    colorClass: {
+    type: {
       control: {
         defaultValue: undefined,
       },

--- a/src/stories/pagefold/Pagefold.stories.tsx
+++ b/src/stories/pagefold/Pagefold.stories.tsx
@@ -10,7 +10,7 @@ export default {
   component: PagefoldComp,
   decorators: [withDesign],
   argTypes: {
-    inherit: {
+    isInheriting: {
       defaultValue: false,
     },
     container: {
@@ -53,10 +53,10 @@ const Template: ComponentStory<typeof PagefoldComp> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  inherit: false,
+  isInheriting: false,
 };
 
 export const Inherit = Template.bind({});
 Inherit.args = {
-  inherit: true,
+  isInheriting: true,
 };

--- a/src/stories/pagefold/Pagefold.tsx
+++ b/src/stories/pagefold/Pagefold.tsx
@@ -1,35 +1,43 @@
+import clsx from "clsx";
 import React from "react";
 
 export type PagefoldProps = {
-  inherit: boolean;
-  container: boolean;
+  isInheriting: boolean;
+  isAContainer: boolean;
   size: "none" | "xsmall" | "small" | "medium" | "large" | "xlarge";
-  colorClass?: "success" | "alert";
+  type?: "success" | "alert";
   children?: React.ReactNode;
-  classes?: string;
+  className?: string;
   compProps?: React.ComponentPropsWithoutRef<"div">;
 };
 
 export const Pagefold = (props: PagefoldProps) => {
   const {
-    inherit,
-    container,
+    isInheriting,
+    isAContainer,
     size,
-    colorClass,
+    type,
     children,
-    classes,
+    className,
     compProps,
   } = props;
-  const containerClass = container ? "internal-pagefold-parent" : "";
 
-  const parent = `pagefold-parent--${size} ${containerClass}  ${classes || ""}`;
-  const child = `pagefold-triangle--${size} ${
-    inherit ? "pagefold-inherit-parent" : ""
-  } ${colorClass ? colorClass : ""}`;
+  const classes = {
+    wrapper: clsx(
+      `pagefold-parent--${size}`,
+      {"internal-pagefold-parent": isAContainer},
+      className
+    ),
+    content: clsx(
+      type,
+      `pagefold-triangle--${size}`,
+      {"pagefold-inherit-parent": isInheriting}
+    )
+  }
 
   return (
-    <div className={parent} {...compProps}>
-      <div className={child} />
+    <div className={classes.wrapper} {...compProps}>
+      <div className={classes.content} />
       {children}
     </div>
   );


### PR DESCRIPTION
* Removing pagefold props from availability label component
  We know what we want to pass inside of the availability component
  so we don't need to expose it
* Make use of map object to construct pagefold props
* Introducing clsx package for cleaner className construction
* Move pagefold prop logic from availability label component to HOC